### PR TITLE
fix(order-form): add target to menuItem and menuQuantity functions to…

### DIFF
--- a/application/src/components/order-form-hook/order-form.js
+++ b/application/src/components/order-form-hook/order-form.js
@@ -10,8 +10,8 @@ export default function OrderForm(props) {
     const [orderItem, setOrderItem] = useState("");
     const [quantity, setQuantity] = useState("1");
 
-    const menuItemChosen = (event) => setOrderItem(event.value);
-    const menuQuantityChosen = (event) => setQuantity(event.value);
+    const menuItemChosen = (event) => setOrderItem(event.target.value);
+    const menuQuantityChosen = (event) => setQuantity(event.target.value);
 
     const auth = useSelector((state) => state.auth);
 


### PR DESCRIPTION
## Changes

1. `event.value` to `event.target.value`

## Purpose

To fix the order form functionality 

## Approach

Add target to the missing value

## Testing Steps

1. Go to order form
2. Select lunch menu and quantity
3. Click order it 
4. Check your orders in the View orders tab

Closes #1